### PR TITLE
Fix to not create duplicate queues

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisQueues.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisQueues.java
@@ -94,6 +94,10 @@ public class RedisQueues implements Closeable {
 		}
 
 		synchronized (this) {
+			queue = this.queues.get(key);
+			if (queue != null) {
+				return queue;
+			}
 			queue = new RedisDynoQueue(redisKeyPrefix, queueName, allShards, shardName, dynoCallExecutor)
 							.withUnackTime(unackTime)
 							.withUnackSchedulerTime(unackHandlerIntervalInMS)


### PR DESCRIPTION
Added a check in the synchronised block to check if the queue was created by a different thread.