### PR TITLE
Refactor queues to use java.time.Clock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ redis-3.0.7.tar.gz
 
 *.iml
 .idea
+.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dyno-queues-core/build
 build
 redis-3.0.7/
 redis-3.0.7.tar.gz
+
+*.iml
+.idea


### PR DESCRIPTION
[Spinnaker's queue library](https://github.com/spinnaker/keiko) TCK uses the Clock interface to validate certain functionality (like retries, rescheduling, etc). This PR updates dyno-queues to use `java.time.Clock` rather than direct calls to `System.currentTimeMillis()` so we can validate that dyno-queues will be a more-or-less drop-in strategy for our orchestration system.