### PR TITLE
Fixed typo

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/Message.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/Message.java
@@ -107,7 +107,7 @@ public class Message {
      */
     public void setPriority(int priority) {
         if (priority < 0 || priority > 99) {
-            throw new IllegalArgumentException("prioirty MUST be between 0 and 99 (inclusive)");
+            throw new IllegalArgumentException("priority MUST be between 0 and 99 (inclusive)");
         }
         this.priority = priority;
     }


### PR DESCRIPTION
Simple typo fixed: 'prioirty' to 'priority'