### PR TITLE
Custom sharding strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ redis-3.0.7.tar.gz
 .gradle
 .classpath
 .project
+
+
+dyno-queues-core/out/
+dyno-queues-redis/out/

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
@@ -92,16 +92,12 @@ public class RedisDynoQueue implements DynoQueue {
 
 	private final ShardingStrategy shardingStrategy;
 	
-	public RedisDynoQueue(String redisKeyPrefix, String queueName, Set<String> allShards, String shardName) {
-		this(redisKeyPrefix, queueName, allShards, shardName, 60_000);
+	public RedisDynoQueue(String redisKeyPrefix, String queueName, Set<String> allShards, String shardName, ShardingStrategy shardingStrategy) {
+		this(redisKeyPrefix, queueName, allShards, shardName, 60_000, shardingStrategy);
 	}
 
-	public RedisDynoQueue(String redisKeyPrefix, String queueName, Set<String> allShards, String shardName, int unackScheduleInMS) {
-		this(Clock.systemDefaultZone(), redisKeyPrefix, queueName, allShards, shardName, unackScheduleInMS);
-	}
-
-	public RedisDynoQueue(Clock clock, String redisKeyPrefix, String queueName, Set<String> allShards, String shardName, int unackScheduleInMS) {
-		this(clock, redisKeyPrefix, queueName, allShards, shardName, unackScheduleInMS, null);
+	public RedisDynoQueue(String redisKeyPrefix, String queueName, Set<String> allShards, String shardName, int unackScheduleInMS, ShardingStrategy shardingStrategy) {
+		this(Clock.systemDefaultZone(), redisKeyPrefix, queueName, allShards, shardName, unackScheduleInMS, shardingStrategy);
 	}
 
 	public RedisDynoQueue(Clock clock, String redisKeyPrefix, String queueName, Set<String> allShards, String shardName, int unackScheduleInMS, ShardingStrategy shardingStrategy) {

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisQueues.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisQueues.java
@@ -69,6 +69,20 @@ public class RedisQueues implements Closeable {
 	}
 
 	/**
+	 * @param quorumConn Dyno connection with dc_quorum enabled
+	 * @param nonQuorumConn	Dyno connection to local Redis
+	 * @param redisKeyPrefix	prefix applied to the Redis keys
+	 * @param shardSupplier	Provider for the shards for the queues created
+	 * @param unackTime	Time in millisecond within which a message needs to be acknowledged by the client, after which the message is re-queued.
+	 * @param unackHandlerIntervalInMS	Time in millisecond at which the un-acknowledgement processor runs
+	 * @param shardingStrategy sharding strategy responsible for calculating message's destination shard
+	 */
+	public RedisQueues(JedisCommands quorumConn, JedisCommands nonQuorumConn, String redisKeyPrefix, ShardSupplier shardSupplier, int unackTime, int unackHandlerIntervalInMS, ShardingStrategy shardingStrategy) {
+		this(Clock.systemDefaultZone(), quorumConn, nonQuorumConn, redisKeyPrefix, shardSupplier, unackTime, unackHandlerIntervalInMS, shardingStrategy);
+	}
+
+
+	/**
 	 * @param clock Time provider
 	 * @param quorumConn Dyno connection with dc_quorum enabled
 	 * @param nonQuorumConn	Dyno connection to local Redis
@@ -76,6 +90,7 @@ public class RedisQueues implements Closeable {
 	 * @param shardSupplier	Provider for the shards for the queues created
 	 * @param unackTime	Time in millisecond within which a message needs to be acknowledged by the client, after which the message is re-queued.
 	 * @param unackHandlerIntervalInMS	Time in millisecond at which the un-acknowledgement processor runs
+	 * @param shardingStrategy sharding strategy responsible for calculating message's destination shard
 	 */
 	public RedisQueues(Clock clock, JedisCommands quorumConn, JedisCommands nonQuorumConn, String redisKeyPrefix, ShardSupplier shardSupplier, int unackTime, int unackHandlerIntervalInMS, ShardingStrategy shardingStrategy) {
 		this.clock = clock;

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisQueues.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisQueues.java
@@ -17,6 +17,8 @@ package com.netflix.dyno.queues.redis;
 
 import com.netflix.dyno.queues.DynoQueue;
 import com.netflix.dyno.queues.ShardSupplier;
+import com.netflix.dyno.queues.redis.sharding.RoundRobinStrategy;
+import com.netflix.dyno.queues.redis.sharding.ShardingStrategy;
 import redis.clients.jedis.JedisCommands;
 
 import java.io.Closeable;
@@ -34,23 +36,25 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class RedisQueues implements Closeable {
 
-	private Clock clock;
+	private final Clock clock;
 
-	private JedisCommands quorumConn;
+	private final JedisCommands quorumConn;
 
-	private JedisCommands nonQuorumConn;
+	private final JedisCommands nonQuorumConn;
 
-	private Set<String> allShards;
+	private final Set<String> allShards;
 
-	private String shardName;
+	private final String shardName;
 
-	private String redisKeyPrefix;
+	private final String redisKeyPrefix;
 
-	private int unackTime;
+	private final int unackTime;
 
-	private int unackHandlerIntervalInMS;
+	private final int unackHandlerIntervalInMS;
 
-	private ConcurrentHashMap<String, DynoQueue> queues;
+	private final ConcurrentHashMap<String, DynoQueue> queues;
+
+	private final ShardingStrategy shardingStrategy;
 
 	/**
 	 * @param quorumConn Dyno connection with dc_quorum enabled
@@ -61,7 +65,7 @@ public class RedisQueues implements Closeable {
 	 * @param unackHandlerIntervalInMS	Time in millisecond at which the un-acknowledgement processor runs
 	 */
 	public RedisQueues(JedisCommands quorumConn, JedisCommands nonQuorumConn, String redisKeyPrefix, ShardSupplier shardSupplier, int unackTime, int unackHandlerIntervalInMS) {
-		this(Clock.systemDefaultZone(), quorumConn, nonQuorumConn, redisKeyPrefix, shardSupplier, unackTime, unackHandlerIntervalInMS);
+		this(Clock.systemDefaultZone(), quorumConn, nonQuorumConn, redisKeyPrefix, shardSupplier, unackTime, unackHandlerIntervalInMS, new RoundRobinStrategy());
 	}
 
 	/**
@@ -73,7 +77,7 @@ public class RedisQueues implements Closeable {
 	 * @param unackTime	Time in millisecond within which a message needs to be acknowledged by the client, after which the message is re-queued.
 	 * @param unackHandlerIntervalInMS	Time in millisecond at which the un-acknowledgement processor runs
 	 */
-	public RedisQueues(Clock clock, JedisCommands quorumConn, JedisCommands nonQuorumConn, String redisKeyPrefix, ShardSupplier shardSupplier, int unackTime, int unackHandlerIntervalInMS) {
+	public RedisQueues(Clock clock, JedisCommands quorumConn, JedisCommands nonQuorumConn, String redisKeyPrefix, ShardSupplier shardSupplier, int unackTime, int unackHandlerIntervalInMS, ShardingStrategy shardingStrategy) {
 		this.clock = clock;
 		this.quorumConn = quorumConn;
 		this.nonQuorumConn = nonQuorumConn;
@@ -83,8 +87,9 @@ public class RedisQueues implements Closeable {
 		this.unackTime = unackTime;
 		this.unackHandlerIntervalInMS = unackHandlerIntervalInMS;
 		this.queues = new ConcurrentHashMap<>();
+		this.shardingStrategy = shardingStrategy;
 	}
-	
+
 	/**
 	 *
 	 * @param queueName Name of the queue
@@ -95,20 +100,11 @@ public class RedisQueues implements Closeable {
 	public DynoQueue get(String queueName) {
 
 		String key = queueName.intern();
-		DynoQueue queue = this.queues.get(key);
-		if (queue != null) {
-			return queue;
-		}
 
-		synchronized (this) {
-			queue = new RedisDynoQueue(clock, redisKeyPrefix, queueName, allShards, shardName, unackHandlerIntervalInMS)
-							.withUnackTime(unackTime)
-							.withNonQuorumConn(nonQuorumConn)
-							.withQuorumConn(quorumConn);
-			this.queues.put(key, queue);
-		}
-
-		return queue;
+        return queues.computeIfAbsent(key, (keyToCompute) -> new RedisDynoQueue(clock, redisKeyPrefix, queueName, allShards, shardName, unackHandlerIntervalInMS, shardingStrategy)
+                .withUnackTime(unackTime)
+                .withNonQuorumConn(nonQuorumConn)
+                .withQuorumConn(quorumConn));
 	}
 
 	/**

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/RoundRobinStrategy.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/RoundRobinStrategy.java
@@ -1,0 +1,28 @@
+package com.netflix.dyno.queues.redis.sharding;
+
+import com.netflix.dyno.queues.Message;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RoundRobinStrategy implements ShardingStrategy {
+
+    private final AtomicInteger nextShardIndex = new AtomicInteger(0);
+
+    /**
+     * Get shard based on round robin strategy.
+     * @param allShards
+     * @param message is ignored in round robin strategy
+     * @return
+     */
+    @Override
+    public String getNextShard(List<String> allShards, Message message) {
+        int index = nextShardIndex.incrementAndGet();
+        if (index >= allShards.size()) {
+            nextShardIndex.set(0);
+            index = 0;
+        }
+        String shard = allShards.get(index);
+        return shard;
+    }
+}

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/RoundRobinStrategy.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/RoundRobinStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.queues.redis.sharding;
 
 import com.netflix.dyno.queues.Message;

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/ShardingStrategy.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/ShardingStrategy.java
@@ -1,0 +1,12 @@
+package com.netflix.dyno.queues.redis.sharding;
+
+import com.netflix.dyno.queues.Message;
+
+import java.util.List;
+
+/**
+ * Expose common interface that allow to apply custom sharding strategy.
+ */
+public interface ShardingStrategy {
+    String getNextShard(List<String> allShards, Message message);
+}

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/ShardingStrategy.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/ShardingStrategy.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.netflix.dyno.queues.redis.sharding;
 
 import com.netflix.dyno.queues.Message;

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -49,35 +49,35 @@ public class RedisPipelineQueue implements DynoQueue {
 
     private final Logger logger = LoggerFactory.getLogger(RedisPipelineQueue.class);
 
-    private Clock clock;
+    private final Clock clock;
 
-    private String queueName;
+    private final String queueName;
 
-    private String shardName;
+    private final String shardName;
 
-    private String messageStoreKeyPrefix;
+    private final String messageStoreKeyPrefix;
 
-    private String myQueueShard;
+    private final String myQueueShard;
 
-    private String unackShardKeyPrefix;
+    private final String unackShardKeyPrefix;
 
-    private int unackTime = 60;
+    private final int unackTime;
 
-    private QueueMonitor monitor;
+    private final QueueMonitor monitor;
 
-    private ObjectMapper om;
+    private final ObjectMapper om;
 
-    private RedisConnection connPool;
+    private final RedisConnection connPool;
 
-    private RedisConnection nonQuorumPool;
+    private volatile RedisConnection nonQuorumPool;
 
-    private ScheduledExecutorService schedulerForUnacksProcessing;
+    private final ScheduledExecutorService schedulerForUnacksProcessing;
 
-    private HashPartitioner partitioner = new Murmur3HashPartitioner();
+    private final HashPartitioner partitioner = new Murmur3HashPartitioner();
 
-    private int maxHashBuckets = 32;
+    private final int maxHashBuckets = 32;
 
-    private int longPollWaitIntervalInMillis = 10;
+    private final int longPollWaitIntervalInMillis = 10;
 
     public RedisPipelineQueue(String redisKeyPrefix, String queueName, String shardName, int unackScheduleInMS, int unackTime, RedisConnection pool) {
         this(Clock.systemDefaultZone(), redisKeyPrefix, queueName, shardName, unackScheduleInMS, unackTime, pool);

--- a/dyno-queues-redis/src/test/java/com/netflix/dyno/queues/redis/DefaultShardingStrategyTest.java
+++ b/dyno-queues-redis/src/test/java/com/netflix/dyno/queues/redis/DefaultShardingStrategyTest.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.dyno.queues.redis;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.queues.Message;
+import com.netflix.dyno.queues.ShardSupplier;
+import com.netflix.dyno.queues.jedis.JedisMock;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class DefaultShardingStrategyTest {
+
+    private static JedisMock dynoClient;
+
+    private static final String queueName = "test_queue";
+
+    private static final String redisKeyPrefix = "testdynoqueues";
+
+    private static RedisDynoQueue shard1DynoQueue;
+    private static RedisDynoQueue shard2DynoQueue;
+    private static RedisDynoQueue shard3DynoQueue;
+
+    private static RedisQueues shard1Queue;
+    private static RedisQueues shard2Queue;
+    private static RedisQueues shard3Queue;
+
+    private static String messageKey;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+
+        HostSupplier hs = new HostSupplier() {
+            @Override
+            public List<Host> getHosts() {
+                List<Host> hosts = new LinkedList<>();
+                hosts.add(new Host("localhost", 8102, "us-east-1d", Host.Status.Up));
+                hosts.add(new Host("localhost", 8102, "us-east-2d", Host.Status.Up));
+                hosts.add(new Host("localhost", 8102, "us-east-3d", Host.Status.Up));
+                return hosts;
+            }
+        };
+
+        dynoClient = new JedisMock();
+
+        Set<String> allShards = hs.getHosts().stream().map(host -> host.getRack().substring(host.getRack().length() - 2)).collect(Collectors.toSet());
+        Iterator<String> iterator = allShards.iterator();
+        String shard1Name = iterator.next();
+        String shard2Name = iterator.next();
+        String shard3Name = iterator.next();
+
+        ShardSupplier shard1Supplier = new ShardSupplier() {
+
+            @Override
+            public Set<String> getQueueShards() {
+                return allShards;
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return shard1Name;
+            }
+        };
+
+        ShardSupplier shard2Supplier = new ShardSupplier() {
+
+            @Override
+            public Set<String> getQueueShards() {
+                return allShards;
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return shard2Name;
+            }
+        };
+
+
+        ShardSupplier shard3Supplier = new ShardSupplier() {
+
+            @Override
+            public Set<String> getQueueShards() {
+                return allShards;
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return shard3Name;
+            }
+        };
+
+        messageKey = redisKeyPrefix + ".MESSAGE." + queueName;
+
+        shard1Queue = new RedisQueues(dynoClient, dynoClient, redisKeyPrefix, shard1Supplier, 1_000, 1_000_000);
+        shard2Queue = new RedisQueues(dynoClient, dynoClient, redisKeyPrefix, shard2Supplier, 1_000, 1_000_000);
+        shard3Queue = new RedisQueues(dynoClient, dynoClient, redisKeyPrefix, shard3Supplier, 1_000, 1_000_000);
+
+
+        shard1DynoQueue = (RedisDynoQueue)shard1Queue.get(queueName);
+        shard2DynoQueue = (RedisDynoQueue)shard2Queue.get(queueName);
+        shard3DynoQueue = (RedisDynoQueue)shard3Queue.get(queueName);
+    }
+
+    @Before
+    public void clearAll()
+    {
+        shard1DynoQueue.clear();
+        shard2DynoQueue.clear();
+        shard3DynoQueue.clear();
+    }
+
+    @Test
+    public void testAll() {
+
+        List<Message> messages = new LinkedList<>();
+
+        Message msg = new Message("1", "Hello World");
+        msg.setPriority(1);
+        messages.add(msg);
+
+        /**
+         * Because of sharding strategy works in round-robin manner, single client, for shard1, should
+         * push message(even the same) to three different shards.
+         */
+        shard1DynoQueue.push(messages);
+        shard1DynoQueue.push(messages);
+        shard1DynoQueue.push(messages);
+
+        List<Message> popedFromShard1 = shard1DynoQueue.pop(1, 1, TimeUnit.SECONDS);
+
+        List<Message> popedFromShard2 = shard2DynoQueue.pop(1, 1, TimeUnit.SECONDS);
+
+        List<Message> popedFromShard3 = shard3DynoQueue.pop(1, 1, TimeUnit.SECONDS);
+
+
+        assertEquals(1, popedFromShard1.size());
+        assertEquals(1, popedFromShard2.size());
+        assertEquals(1, popedFromShard3.size());
+
+        assertEquals(msg, popedFromShard1.get(0));
+        assertEquals(msg, popedFromShard2.get(0));
+        assertEquals(msg, popedFromShard3.get(0));
+
+    }
+
+}

--- a/dyno-queues-redis/src/test/java/com/netflix/dyno/queues/redis/v2/CustomShardingStrategyTest.java
+++ b/dyno-queues-redis/src/test/java/com/netflix/dyno/queues/redis/v2/CustomShardingStrategyTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2016 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.dyno.queues.redis.v2;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.queues.Message;
+import com.netflix.dyno.queues.ShardSupplier;
+import com.netflix.dyno.queues.jedis.JedisMock;
+import com.netflix.dyno.queues.redis.RedisDynoQueue;
+import com.netflix.dyno.queues.redis.RedisQueues;
+import com.netflix.dyno.queues.redis.sharding.ShardingStrategy;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class CustomShardingStrategyTest {
+
+    public static class HashBasedStrategy implements ShardingStrategy {
+        @Override
+        public String getNextShard(List<String> allShards, Message message) {
+            int hashCodeAbs = Math.abs(message.getId().hashCode());
+            int calculatedShard = (hashCodeAbs % allShards.size()) + 1;
+            return Integer.toString(calculatedShard);
+        }
+    }
+
+    private static JedisMock dynoClient;
+
+    private static final String queueName = "test_queue";
+
+    private static final String redisKeyPrefix = "testdynoqueues";
+
+    private static RedisDynoQueue shard1DynoQueue;
+    private static RedisDynoQueue shard2DynoQueue;
+    private static RedisDynoQueue shard3DynoQueue;
+
+    private static RedisQueues shard1Queue;
+    private static RedisQueues shard2Queue;
+    private static RedisQueues shard3Queue;
+
+    private static String messageKey;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+
+        HostSupplier hs = new HostSupplier() {
+            @Override
+            public List<Host> getHosts() {
+                List<Host> hosts = new LinkedList<>();
+                hosts.add(new Host("host1", 8102, "rack1", Host.Status.Up));
+                hosts.add(new Host("host2", 8102, "rack2", Host.Status.Up));
+                hosts.add(new Host("host3", 8102, "rack3", Host.Status.Up));
+                return hosts;
+            }
+        };
+
+        dynoClient = new JedisMock();
+
+        Set<String> allShards = hs.getHosts().stream().map(host -> host.getRack().substring(host.getRack().length() - 2)).collect(Collectors.toSet());
+
+        ShardSupplier shard1Supplier = new ShardSupplier() {
+
+            @Override
+            public Set<String> getQueueShards() {
+                return allShards;
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return "1";
+            }
+        };
+
+        ShardSupplier shard2Supplier = new ShardSupplier() {
+
+            @Override
+            public Set<String> getQueueShards() {
+                return allShards;
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return "2";
+            }
+        };
+
+
+        ShardSupplier shard3Supplier = new ShardSupplier() {
+
+            @Override
+            public Set<String> getQueueShards() {
+                return allShards;
+            }
+
+            @Override
+            public String getCurrentShard() {
+                return "3";
+            }
+        };
+
+        messageKey = redisKeyPrefix + ".MESSAGE." + queueName;
+
+        HashBasedStrategy hashBasedStrategy = new HashBasedStrategy();
+
+        shard1Queue = new RedisQueues(dynoClient, dynoClient, redisKeyPrefix, shard1Supplier, 1_000, 1_000_000, hashBasedStrategy);
+        shard2Queue = new RedisQueues(dynoClient, dynoClient, redisKeyPrefix, shard2Supplier, 1_000, 1_000_000, hashBasedStrategy);
+        shard3Queue = new RedisQueues(dynoClient, dynoClient, redisKeyPrefix, shard3Supplier, 1_000, 1_000_000, hashBasedStrategy);
+
+        shard1DynoQueue = (RedisDynoQueue) shard1Queue.get(queueName);
+        shard2DynoQueue = (RedisDynoQueue) shard2Queue.get(queueName);
+        shard3DynoQueue = (RedisDynoQueue) shard3Queue.get(queueName);
+    }
+
+    @Before
+    public void clearAll() {
+        shard1DynoQueue.clear();
+        shard2DynoQueue.clear();
+        shard3DynoQueue.clear();
+    }
+
+    @Test
+    public void testAll() {
+
+        List<Message> messages = new LinkedList<>();
+
+        Message msg = new Message("1", "Hello World");
+        msg.setPriority(1);
+        messages.add(msg);
+
+        /**
+         * Because my custom sharding strategy that depends on message id, and calculated hash (just Java's hashCode),
+         * message will always ends on the same shard, so message never duplicates, in test case, I expect that
+         * message will be received only once.
+         */
+        shard1DynoQueue.push(messages);
+        shard1DynoQueue.push(messages);
+        shard1DynoQueue.push(messages);
+
+        List<Message> popedFromShard1 = shard1DynoQueue.pop(1, 1, TimeUnit.SECONDS);
+
+        List<Message> popedFromShard2 = shard2DynoQueue.pop(1, 1, TimeUnit.SECONDS);
+
+        List<Message> popedFromShard3 = shard3DynoQueue.pop(1, 1, TimeUnit.SECONDS);
+
+
+        assertEquals(0, popedFromShard1.size());
+        assertEquals(1, popedFromShard2.size());
+        assertEquals(0, popedFromShard3.size());
+
+        assertEquals(msg, popedFromShard2.get(0));
+    }
+}


### PR DESCRIPTION
Motivation : 
recently we faced problem with re-scheduling already scheduled event, because of hard-coded sharding strategy it was impossible. 
Additionally I fixed problems with JMM (at least in my opinion problems), for example, all object that has no final keyword for object properties are not guaranteed to be visible by other threads (without proper synchronization), only the properties with ```final``` keyword have store barrier inserted after their initialisation. 

I will continue to work on that, if you will tell that this feature it is ok for you :) 

Thanks !

 