### PR TITLE
Updates dyno to v1.6.5 stable release

### DIFF
--- a/dyno-queues-redis/build.gradle
+++ b/dyno-queues-redis/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     
     compile "com.google.inject:guice:3.0"
 
-    compile 'com.netflix.dyno:dyno-core:1.6.5-rc.1'
-    compile 'com.netflix.dyno:dyno-jedis:1.6.5-rc.1'
+    compile 'com.netflix.dyno:dyno-core:1.6.5'
+    compile 'com.netflix.dyno:dyno-jedis:1.6.5'
 
     compile 'com.netflix.archaius:archaius-core:0.7.5'
     compile 'com.netflix.servo:servo-core:0.12.17'


### PR DESCRIPTION
In order to get Redis authentication support into Conductor, I'd like to submit a PR to upgrade `dyno` to `v1.6.5`, so that it can be pulled into an upcoming release. 

Please see Netflix/dyno#244 for additional detail.

