### PR TITLE
returning shard directly without assigning to variable

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/RoundRobinStrategy.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/sharding/RoundRobinStrategy.java
@@ -37,7 +37,6 @@ public class RoundRobinStrategy implements ShardingStrategy {
             nextShardIndex.set(0);
             index = 0;
         }
-        String shard = allShards.get(index);
-        return shard;
+        return allShards.get(index);
     }
 }


### PR DESCRIPTION
assigning the shard to a variable can be skipped. 