### PR TITLE
DynoShardSupplier should return consistent results through its APIs

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/DynoShardSupplier.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/DynoShardSupplier.java
@@ -50,7 +50,7 @@ public class DynoShardSupplier implements ShardSupplier {
 	
 	@Override
 	public String getCurrentShard() {
-		return localRack;
+		return localRack.replaceAll(region, "");
 	}
 	
 	@Override


### PR DESCRIPTION
The getQueueShards() call returns all the shards with the region
filtered out from the strings in the final list. However, the
getCurrentShard() API returns the shard name as is. This can cause
items to get lost in the queue depending on how the regions and racks
(which the shards derive their names from) are supplied.

This patch fixes the above issue and makes both the APIs consistent with
their results.