### PR TITLE
Add unsafe_peekAllShards() and unsafe_popAllShards() functions

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -224,4 +224,14 @@ public class MultiRedisQueue implements DynoQueue {
         return s;
     }
 
+    @Override
+    public List<Message> unsafePeekAllShards(final int messageCount) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Message> unsafePopAllShards(int messageCount, int wait, TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -648,4 +648,14 @@ public class RedisPipelineQueue implements DynoQueue {
         schedulerForUnacksProcessing.shutdown();
         monitor.close();
     }
+
+    @Override
+    public List<Message> unsafePeekAllShards(final int messageCount) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Message> unsafePopAllShards(int messageCount, int wait, TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/dyno-queues-redis/src/test/java/com/netflix/dyno/queues/redis/RedisDynoQueueTest.java
+++ b/dyno-queues-redis/src/test/java/com/netflix/dyno/queues/redis/RedisDynoQueueTest.java
@@ -251,7 +251,7 @@ public class RedisDynoQueueTest {
         long elapsedTime = System.currentTimeMillis() - start;
         assertTrue(elapsedTime >= 1000);
         assertEquals(0, more.size());
-        assertEquals(0, rdq.prefetch.get());
+        assertEquals(0, rdq.numIdsToPrefetch.get());
 
         ses.shutdownNow();
     }


### PR DESCRIPTION
This patch exposes 2 new APIs that allow the calling application to
peek into and pop from all shards of the queue.

The APIs are prepended with unsafe_* because if multiple client app
instances call these APIs concurrently, it's possible that duplicate
items may be returned to the application across client instances. Hence,
these APIs must not be used unless the calling application's use case
is okay with handling duplicate items.

The DynoQueueDemo is updated to use these new APIs.

Additionally, a lot of the code is refactored in V1.