### PR TITLE
Update dyno dependency to 1.6.9

### DIFF
--- a/dyno-queues-core/build.gradle
+++ b/dyno-queues-core/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-	compile 'com.netflix.dyno:dyno-core:1.6.7'
+	compile 'com.netflix.dyno:dyno-core:1.6.9'
 	testCompile "junit:junit:4.11"
 }

--- a/dyno-queues-redis/build.gradle
+++ b/dyno-queues-redis/build.gradle
@@ -4,9 +4,9 @@ dependencies {
 
     compile "com.google.inject:guice:3.0"
 
-    compile 'com.netflix.dyno:dyno-core:1.6.7'
-    compile 'com.netflix.dyno:dyno-jedis:1.6.7'
-    compile 'com.netflix.dyno:dyno-demo:1.6.7'
+    compile 'com.netflix.dyno:dyno-core:1.6.9'
+    compile 'com.netflix.dyno:dyno-jedis:1.6.9'
+    compile 'com.netflix.dyno:dyno-demo:1.6.9'
 
     compile 'com.netflix.archaius:archaius-core:0.7.5'
     compile 'com.netflix.servo:servo-core:0.12.17'


### PR DESCRIPTION
1.6.7 has bugs in it which has been fixed in the new version.