### PR TITLE
getMsgWithPredicate() should use nonQuorumConn

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
@@ -477,7 +477,7 @@ public class RedisDynoQueue implements DynoQueue {
                     "return nil";
 
             // Cast from 'JedisCommands' to 'DynoJedisClient' here since the former does not expose 'eval()'.
-            String retval = (String) ((DynoJedisClient) quorumConn).eval(predicateCheckLuaScript,
+            String retval = (String) ((DynoJedisClient) nonQuorumConn).eval(predicateCheckLuaScript,
                     Collections.singletonList(messageStoreKey), Collections.singletonList(predicate));
 
             return retval;


### PR DESCRIPTION
Each hashmap across replicas can have the same items in different orders.
Therefore, it's possible that getMsgWithPredicate() can have a quorum
failure since each replica matched the predicate with a different
message ID.

This patch changes it to nonQuorumConn, as any one valid message ID
would do.