### PR TITLE
Add a popWithMsgId() API

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -63,6 +63,15 @@ public interface DynoQueue extends Closeable {
     public List<Message> pop(int messageCount, int wait, TimeUnit unit);
 
     /**
+     * Pops "messageId" from the local shard if it exists.
+     * Note that if "messageId" is present in a different shard, we will be unable to pop it.
+     *
+     * @param messageId ID of message to pop
+     * @return Returns a "Message" object if pop was successful. 'null' otherwise.
+     */
+    public Message popWithMsgId(String messageId);
+
+    /**
      * Provides a peek into the queue without taking messages out.
      * @param messageCount number of messages to be peeked.
      * @return List of peeked messages.

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -90,6 +90,10 @@ public class MultiRedisQueue implements DynoQueue {
     }
 
     @Override
+    public Message popWithMsgId(String messageId) {
+        throw new UnsupportedOperationException();
+    }
+    @Override
     public List<Message> peek(int messageCount) {
         return me.peek(messageCount);
     }

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -245,6 +245,10 @@ public class RedisPipelineQueue implements DynoQueue {
 
     }
 
+    @Override
+    public Message popWithMsgId(String messageId) {
+        throw new UnsupportedOperationException();
+    }
     private List<Message> _pop(List<String> batch) throws Exception {
 
         double unackScore = Long.valueOf(clock.millis() + unackTime).doubleValue();


### PR DESCRIPTION
This allows users to pop a specific message ID from the queue. Note that
if the message will be popped only if the local shard contains the
message.

Test added to DynoQueueDemo.