### PR TITLE
Allow Lua pattern matching in containsPredicate() and getMsgWithPredi…

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -129,6 +129,9 @@ public interface DynoQueue extends Closeable {
      * Checks the message bodies (i.e. the data in the hash map), and returns true on the first match with
      * 'predicate'.
      *
+     * Matching is done based on 'lua pattern' matching.
+     * http://lua-users.org/wiki/PatternsTutorial
+     *
      * Disclaimer: This is a potentially expensive call, since we will iterate over the entire hash map in the
      * worst case. Use mindfully.
      *
@@ -140,6 +143,9 @@ public interface DynoQueue extends Closeable {
     /**
      * Checks the message bodies (i.e. the data in the hash map), and returns the ID of the first message to match with
      * 'predicate'.
+     *
+     * Matching is done based on 'lua pattern' matching.
+     * http://lua-users.org/wiki/PatternsTutorial
      *
      * Disclaimer: This is a potentially expensive call, since we will iterate over the entire hash map in the
      * worst case. Use mindfully.

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
@@ -83,7 +83,7 @@ public class DynoQueueDemo extends DynoJedisDemo {
         RedisQueues queues = new RedisQueues(dyno, dyno, prefix, ss, 50_000, 50_000);
 
         List<Message> payloads = new ArrayList<>();
-        payloads.add(new Message("id1", "searchable payload"));
+        payloads.add(new Message("id1", "searchable payload123"));
         payloads.add(new Message("id2", "payload 2"));
         payloads.add(new Message("id3", "payload 3"));
         payloads.add(new Message("id4", "payload 4"));
@@ -105,7 +105,7 @@ public class DynoQueueDemo extends DynoJedisDemo {
         logger.info("Does the predicate 'searchable' exist in  the queue? -> " + V1Queue.containsPredicate("searchable"));
 
         // Test getMsgWithPredicate() API
-        logger.info("Get MSG ID that contains 'searchable' in the queue -> " + V1Queue.getMsgWithPredicate("searchable"));
+        logger.info("Get MSG ID that contains 'searchable' in the queue -> " + V1Queue.getMsgWithPredicate("searchable pay*"));
 
         List<Message> specific_pops = new ArrayList<>();
         // We'd only be able to pop from the local shard, so try to pop the first payload ID we see in the local shard.

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
@@ -522,7 +522,7 @@ public class RedisDynoQueue implements DynoQueue {
                     "  for i, content in ipairs(ret[2]) do\n" +
                     "    if (i % 2 ~= 0) then\n" +
                     "      curmsgid = content\n" +
-                    "    elseif (string.find(content, predicate)) then\n" +
+                    "    elseif (string.match(content, predicate)) then\n" +
                     "      return curmsgid\n" +
                     "    end\n" +
                     "  end\n" +


### PR DESCRIPTION
…cate()

Previously we used string.find() which would match only a letter by
letter match. This patch converts it to use LUA pattern matching which
can do more complicated comparisons.

Lua Pattern matching:
http://lua-users.org/wiki/PatternsTutorial