### PR TITLE
unsafePopAllShards() should use the prefetched IDs from the unsafe Map

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
@@ -92,6 +92,12 @@ public class DynoQueueDemo extends DynoJedisDemo {
         payloads.add(new Message("id7", "payload 7"));
         payloads.add(new Message("id8", "payload 8"));
         payloads.add(new Message("id9", "payload 9"));
+        payloads.add(new Message("id10", "payload 10"));
+        payloads.add(new Message("id11", "payload 11"));
+        payloads.add(new Message("id12", "payload 12"));
+        payloads.add(new Message("id13", "payload 13"));
+        payloads.add(new Message("id14", "payload 14"));
+        payloads.add(new Message("id15", "payload 15"));
 
         DynoQueue V1Queue = queues.get("simpleQueue");
 
@@ -132,7 +138,7 @@ public class DynoQueueDemo extends DynoJedisDemo {
         assert(removed);
 
         // Test pop(). Even though we try to pop 3 messages, there will only be one remaining message in our local shard.
-        List<Message> popped_msgs = V1Queue.pop(3, 1000, TimeUnit.MILLISECONDS);
+        List<Message> popped_msgs = V1Queue.pop(1, 1000, TimeUnit.MILLISECONDS);
         V1Queue.ack(popped_msgs.get(0).getId());
 
         // Test unsafePeekAllShards()

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
@@ -421,7 +421,7 @@ public class RedisDynoQueue implements DynoQueue {
             int remainingCount = messageCount;
             // Pop as much as possible from the local shard first to reduce chances of returning duplicate items.
             // (See unsafe* functions disclaimer in DynoQueue.java)
-            List<Message> popped = _pop(shardName, remainingCount, prefetchedIds);
+            List<Message> popped = _pop(shardName, remainingCount, unsafePrefetchedIdsAllShardsMap.get(localQueueShard));
             remainingCount -= popped.size();
 
             for (String shard : allShards) {


### PR DESCRIPTION
To preserve the order of having local shard IDs show up first, use
the 'unsafePrefetchedIdsAllShardsMap' instead of 'prefetchedIds'
as we don't refresh 'prefetchedIds' on unsafePopAllShards() but
rather only during pop().

Modified the demo to confirm this behavior.

TODO: unsafePeekIdsAllShards() does not respect the local shard order.
This needs to be fixed by moving internal representation of elements in
a LIst as opposed to a Set.