### PR TITLE
Add a new ShardSupplier to address issues with DynoShardSupplier

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
@@ -6,7 +6,7 @@ import com.netflix.dyno.queues.DynoQueue;
 import com.netflix.dyno.queues.Message;
 import com.netflix.dyno.queues.redis.RedisQueues;
 import com.netflix.dyno.queues.redis.v2.QueueBuilder;
-import com.netflix.dyno.queues.shard.DynoShardSupplier;
+import com.netflix.dyno.queues.shard.ConsistentAWSDynoShardSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,7 +78,7 @@ public class DynoQueueDemo extends DynoJedisDemo {
 
         String prefix = "dynoQueue_";
 
-        DynoShardSupplier ss = new DynoShardSupplier(dyno.getConnPool().getConfiguration().getHostSupplier(), region, localRack);
+        ConsistentAWSDynoShardSupplier ss = new ConsistentAWSDynoShardSupplier(dyno.getConnPool().getConfiguration().getHostSupplier(), region, localRack);
 
         RedisQueues queues = new RedisQueues(dyno, dyno, prefix, ss, 50_000, 50_000);
 

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/ConsistentAWSDynoShardSupplier.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/ConsistentAWSDynoShardSupplier.java
@@ -1,0 +1,37 @@
+package com.netflix.dyno.queues.shard;
+
+import com.netflix.dyno.connectionpool.HostSupplier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConsistentAWSDynoShardSupplier extends ConsistentDynoShardSupplier {
+
+    /**
+     * Dynomite based shard supplier. Keeps the number of shards in parity with the hosts and regions
+     *
+     * Note: This ensures that all racks use the same shard names. This fixes issues with the now deprecated DynoShardSupplier
+     * that would write to the wrong shard if there are cross-region writers/readers.
+     *
+     * @param hs Host supplier
+     * @param region current region
+     * @param localRack local rack identifier
+     */
+    public ConsistentAWSDynoShardSupplier(HostSupplier hs, String region, String localRack) {
+        super(hs, region, localRack);
+        Map<String, String> rackToHashMapEntries = new HashMap<String, String>() {{
+            this.put("us-east-1c", "c");
+            this.put("us-east-1d", "d");
+            this.put("us-east-1e", "e");
+
+            this.put("eu-west-1a", "c");
+            this.put("eu-west-1b", "d");
+            this.put("eu-west-1c", "e");
+
+            this.put("us-west-2a", "c");
+            this.put("us-west-2b", "d");
+            this.put("us-west-2c", "e");
+        }};
+        setRackToShardMap(rackToHashMapEntries);
+    }
+}

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/ConsistentDynoShardSupplier.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/ConsistentDynoShardSupplier.java
@@ -1,0 +1,54 @@
+package com.netflix.dyno.queues.shard;
+
+import com.netflix.dyno.connectionpool.Host;
+import com.netflix.dyno.connectionpool.HostSupplier;
+import com.netflix.dyno.queues.ShardSupplier;
+
+import java.util.*;
+
+abstract class ConsistentDynoShardSupplier implements ShardSupplier {
+
+    protected HostSupplier hs;
+
+    protected  String region;
+
+    protected String localRack;
+
+    protected Map<String, String> rackToShardMap;
+
+    /**
+     * Dynomite based shard supplier.  Keeps the number of shards in parity with the hosts and regions
+     * @param hs Host supplier
+     * @param region current region
+     * @param localRack local rack identifier
+     */
+    public ConsistentDynoShardSupplier(HostSupplier hs, String region, String localRack) {
+        this.hs = hs;
+        this.region = region;
+        this.localRack = localRack;
+    }
+
+    public void setRackToShardMap(Map<String, String> rackToShardMapEntries) {
+        rackToShardMap = new HashMap<>(rackToShardMapEntries);
+    }
+
+    @Override
+    public String getCurrentShard() {
+        return rackToShardMap.get(localRack);
+    }
+
+    @Override
+    public Set<String> getQueueShards() {
+        Set<String> queueShards = new HashSet<>();
+        List<Host> hosts = hs.getHosts();
+        for (Host host : hosts) {
+            queueShards.add(rackToShardMap.get(host.getRack()));
+        }
+        return queueShards;
+    }
+
+    @Override
+    public String getShardForHost(Host host) {
+        return rackToShardMap.get(host.getRack());
+    }
+}

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/DynoShardSupplier.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/DynoShardSupplier.java
@@ -29,7 +29,11 @@ import java.util.stream.Collectors;
 /**
  * @author Viren
  *
+ * NOTE: This class is deprecated and should not be used. It still remains for backwards compatibility for legacy applications
+ * New applications must use 'ConsistentAWSDynoShardSupplier' or extend 'ConsistentDynoShardSupplier' for non-AWS environments.
+ *
  */
+@Deprecated
 public class DynoShardSupplier implements ShardSupplier {
 
     private HostSupplier hs;


### PR DESCRIPTION
DynoShardSupplier supplies the shard names based on AWS regions and
zones of the calling application.

This works fine if the calling application is present only in one
region (across all zones in the region).

However, if we have calling applications that are distributed across
regions, we will get into trouble with DynoShardSupplier.

For example:
- Assume a queue called 'simple_queue'.
- App in us-east-1d pushes to the queue and it ends up in shard
  'simple_queue.d'.
- The counterpart for us-east-1d in the EU-west region is eu-west-1b.
- When eu-west-1b tries to pop, because of the DynoShardSupplier, it
  will attempt to pop from 'simple_queue.b', which does not even exist
  at this point.

ConsistentDynoShardSupplier is added as an abstract class to deal with
this issue. ConsistentAWSDynoShardSupplier inherits from it and
hardcodes mappings for all racks we'd use in the AWS environment.
Non-AWS users may extend ConsistentDynoShardSupplier and create
different mappings.

The DynoShardSupplier is left in the codebase and marked as deprecated
for legacy applications using it.