### PR TITLE
Allow containsPredicate()/getMsgWithPredicate() to filter on local shard

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -141,9 +141,13 @@ public interface DynoQueue extends Closeable {
      * worst case. Use mindfully.
      *
      * @param predicate The predicate to check against.
+     * @param localShardOnly If this is true, it will only check if the message exists in the local shard as opposed to
+     *                       all shards. Note that this will only work if the Dynomite cluster ring size is 1 (i.e. one
+     *                       instance per AZ).
      * @return 'true' if any of the messages contain 'predicate'; 'false' otherwise.
      */
     public boolean containsPredicate(String predicate);
+    public boolean containsPredicate(String predicate, boolean localShardOnly);
 
     /**
      * Checks the message bodies (i.e. the data in the hash map), and returns the ID of the first message to match with
@@ -156,9 +160,13 @@ public interface DynoQueue extends Closeable {
      * worst case. Use mindfully.
      *
      * @param predicate The predicate to check against.
+     * @param localShardOnly If this is true, it will only check if the message exists in the local shard as opposed to
+     *                       all shards. Note that this will only work if the Dynomite cluster ring size is 1 (i.e. one
+     *                       instance per AZ).
      * @return Message ID as string if any of the messages contain 'predicate'; 'null' otherwise.
      */
     public String getMsgWithPredicate(String predicate);
+    public String getMsgWithPredicate(String predicate, boolean localShardOnly);
 
     /**
      *

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
@@ -117,6 +117,11 @@ public class DynoQueueDemo extends DynoJedisDemo {
         // Test getMsgWithPredicate() API
         logger.info("Get MSG ID that contains 'searchable' in the queue -> " + V1Queue.getMsgWithPredicate("searchable pay*"));
 
+        // Test getMsgWithPredicate(predicate, localShardOnly=true) API
+        // NOTE: This only works on single ring sized Dynomite clusters.
+        logger.info("Get MSG ID that contains 'searchable' in the queue -> " + V1Queue.getMsgWithPredicate("searchable pay*", true));
+        logger.info("Get MSG ID that contains '3' in the queue -> " + V1Queue.getMsgWithPredicate("3", true));
+
         List<Message> specific_pops = new ArrayList<>();
         // We'd only be able to pop from the local shard, so try to pop the first payload ID we see in the local shard.
         for (int i = 0; i < payloads.size(); ++i) {

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -151,13 +151,24 @@ public class MultiRedisQueue implements DynoQueue {
         throw new UnsupportedOperationException();
     }
 
+
     @Override
     public boolean containsPredicate(String predicate) {
-        throw new UnsupportedOperationException();
+        return containsPredicate(predicate, false);
     }
 
     @Override
     public String getMsgWithPredicate(String predicate) {
+        return getMsgWithPredicate(predicate, false);
+    }
+
+    @Override
+    public boolean containsPredicate(String predicate, boolean localShardOnly) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMsgWithPredicate(String predicate, boolean localShardOnly) {
         throw new UnsupportedOperationException();
     }
 

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -468,11 +468,21 @@ public class RedisPipelineQueue implements DynoQueue {
 
     @Override
     public boolean containsPredicate(String predicate) {
-        throw new UnsupportedOperationException();
+        return containsPredicate(predicate, false);
     }
 
     @Override
     public String getMsgWithPredicate(String predicate) {
+        return getMsgWithPredicate(predicate, false);
+    }
+
+    @Override
+    public boolean containsPredicate(String predicate, boolean localShardOnly) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMsgWithPredicate(String predicate, boolean localShardOnly) {
         throw new UnsupportedOperationException();
     }
 

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/ConsistentDynoShardSupplier.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/shard/ConsistentDynoShardSupplier.java
@@ -10,7 +10,7 @@ abstract class ConsistentDynoShardSupplier implements ShardSupplier {
 
     protected HostSupplier hs;
 
-    protected  String region;
+    protected String region;
 
     protected String localRack;
 


### PR DESCRIPTION
NOTE: This will only work against Dynomite clusters that have a single
ring size.

This extends the APIs to only return if the predicate belongs to a
message ID that belongs to the local shard of the calling instance.

Testing: Added to the Demo and confirmed working.