### PR TITLE
Add unsafePopWithMsgIdAllShards() API

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -240,4 +240,14 @@ public interface DynoQueue extends Closeable {
 	 *
 	 */
 	public List<Message> unsafePopAllShards(int messageCount, int wait, TimeUnit unit);
+
+
+	/**
+	 * Same as popWithMsgId(), but allows popping from any shard.
+	 *
+	 * @param messageId ID of message to pop
+	 * @return Returns a "Message" object if pop was successful. 'null' otherwise.
+	 */
+	public Message unsafePopWithMsgIdAllShards(String messageId);
+
 }

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -93,6 +93,12 @@ public class MultiRedisQueue implements DynoQueue {
     public Message popWithMsgId(String messageId) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Message unsafePopWithMsgIdAllShards(String messageId) {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public List<Message> peek(int messageCount) {
         return me.peek(messageCount);

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -249,6 +249,12 @@ public class RedisPipelineQueue implements DynoQueue {
     public Message popWithMsgId(String messageId) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Message unsafePopWithMsgIdAllShards(String messageId) {
+        throw new UnsupportedOperationException();
+    }
+
     private List<Message> _pop(List<String> batch) throws Exception {
 
         double unackScore = Long.valueOf(clock.millis() + unackTime).doubleValue();


### PR DESCRIPTION
Similar to popWithMsgId(), but attempts to pop from any shard.
Hence, prefixed with unsafe.

Testing: Added a test to the DynoQueueDemo.