### PR TITLE
Use object form of Long for zrank() return type

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
@@ -369,12 +369,9 @@ public class RedisDynoQueue implements DynoQueue {
 
             ZAddParams zParams = ZAddParams.zAddParams().nx();
 
-            try {
-                long exists = nonQuorumConn.zrank(queueShardName, messageId);
-                // If an exception wasn't thrown, the element has to exist.
-                assert(exists >= 0);
-            } catch (NullPointerException e) {
-                // If we get a NPE, that means "messageId" does not exist in the sorted set.
+            Long exists = nonQuorumConn.zrank(queueShardName, messageId);
+            // If we get back a null type, then the element doesn't exist.
+            if (exists == null) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Cannot find the message with ID {}", messageId);
                 }


### PR DESCRIPTION
The Jedis docs for each command are just a copy paste of Redis docs
which doesn't translate well to Java.
https://github.com/xetorthio/jedis/issues/978

From some stack overflow googling, we see the right way to use
zrank(), and this patch changes the code to comply with that.