### PR TITLE
Add popMsgWithPredicate() API

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -168,6 +168,17 @@ public interface DynoQueue extends Closeable {
     public String getMsgWithPredicate(String predicate);
     public String getMsgWithPredicate(String predicate, boolean localShardOnly);
 
+	/**
+	 * Same as getMsgWithPredicate(), but it also pops the item if found.
+	 *
+	 * @param predicate The predicate to check against.
+	 * @param localShardOnly If this is true, it will only check if the message exists in the local shard as opposed to
+	 *                       all shards. Note that this will only work if the Dynomite cluster ring size is 1 (i.e. one
+	 *                       instance per AZ).
+	 * @return
+	 */
+	public Message popMsgWithPredicate(String predicate, boolean localShardOnly);
+
     /**
      *
      * @param messageId message to be retrieved.

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/demo/DynoQueueDemo.java
@@ -72,6 +72,7 @@ public class DynoQueueDemo extends DynoJedisDemo {
         }
     }
 
+
     private void runSimpleV1Demo(DynoJedisClient dyno) throws IOException {
         String region = System.getProperty("LOCAL_DATACENTER");
         String localRack = System.getProperty("LOCAL_RACK");
@@ -122,10 +123,13 @@ public class DynoQueueDemo extends DynoJedisDemo {
         logger.info("Get MSG ID that contains 'searchable' in the queue -> " + V1Queue.getMsgWithPredicate("searchable pay*", true));
         logger.info("Get MSG ID that contains '3' in the queue -> " + V1Queue.getMsgWithPredicate("3", true));
 
+        Message poppedWithPredicate = V1Queue.popMsgWithPredicate("searchable pay*", false);
+        V1Queue.ack(poppedWithPredicate.getId());
+
         List<Message> specific_pops = new ArrayList<>();
         // We'd only be able to pop from the local shard with popWithMsgId(), so try to pop the first payload ID we see in the local shard.
         // Until then pop all messages not in the local shard with unsafePopWithMsgIdAllShards().
-        for (int i = 0; i < payloads.size(); ++i) {
+        for (int i = 1; i < payloads.size(); ++i) {
             Message popWithMsgId = V1Queue.popWithMsgId(payloads.get(i).getId());
             if (popWithMsgId != null) {
                 specific_pops.add(popWithMsgId);

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -179,6 +179,11 @@ public class MultiRedisQueue implements DynoQueue {
     }
 
     @Override
+    public Message popMsgWithPredicate(String predicate, boolean localShardOnly) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Message get(String messageId) {
         for (DynoQueue q : queues.values()) {
             Message msg = q.get(messageId);

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -493,6 +493,11 @@ public class RedisPipelineQueue implements DynoQueue {
     }
 
     @Override
+    public Message popMsgWithPredicate(String predicate, boolean localShardOnly) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Message get(String messageId) {
 
         Stopwatch sw = monitor.get.start();


### PR DESCRIPTION
This API looks for a value with a matching predicate in the hashmap and pops
the first message ID that matches if it does find one.

Also added a atomicPopWithMsgIdHelper() helper function to do a pop in one
round trip. This should only be used if the ring size of the underlying
Dynomite cluster is 1.

Testing: Tested with DynoQueueDemo