### PR TITLE
Add a atomic bulkPop() API

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -186,6 +186,8 @@ public interface DynoQueue extends Closeable {
      */
     public Message get(String messageId);
 
+    public List<Message> bulkPop(int messageCount, int wait, TimeUnit unit);
+
     /**
      *
      * @return Size of the queue.

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -184,6 +184,11 @@ public class MultiRedisQueue implements DynoQueue {
     }
 
     @Override
+    public List<Message> bulkPop(int messageCount, int wait, TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Message get(String messageId) {
         for (DynoQueue q : queues.values()) {
             Message msg = q.get(messageId);

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -498,6 +498,11 @@ public class RedisPipelineQueue implements DynoQueue {
     }
 
     @Override
+    public List<Message> bulkPop(int messageCount, int wait, TimeUnit unit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Message get(String messageId) {
 
         Stopwatch sw = monitor.get.start();


### PR DESCRIPTION
Using queues with DC_EACH_SAFE_QUORUM is quite expensive. The bulk
pop operation is meant to pop more within  a single round trip.