### PR TITLE
Make popWithMsgPredicate() obey queue priority

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -169,7 +169,9 @@ public interface DynoQueue extends Closeable {
     public String getMsgWithPredicate(String predicate, boolean localShardOnly);
 
 	/**
-	 * Same as getMsgWithPredicate(), but it also pops the item if found.
+	 * Pops the message with the highest priority that matches 'predicate'.
+	 *
+	 * Note: Can be slow for large queues.
 	 *
 	 * @param predicate The predicate to check against.
 	 * @param localShardOnly If this is true, it will only check if the message exists in the local shard as opposed to


### PR DESCRIPTION
Previously popWithMsgPredicate() would pop the first item it found
in the hashmap that matches the given predicate. With this patch, it
will obey the queueing priority.