### PR TITLE
Make popMsgWithPredicateObeyPriority() check if hash exists

### DIFF
--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/RedisDynoQueue.java
@@ -859,12 +859,14 @@ public class RedisDynoQueue implements DynoQueue {
                 "        num_complete_shards = num_complete_shards + 1\n" +
                 "      else\n" +
                 "        local value = redis.call('hget', hkey, tostring(element[1]))\n" +
-                "        if (string.match(value, predicate)) then\n" +
-                "          if (min_score == -1 or tonumber(element[2]) < min_score) then\n" +
-                "            min_score = tonumber(element[2])\n" +
-                "            owning_shard_idx=i\n" +
-                "            min_member = element[1]\n" +
-                "            matching_value = value\n" +
+                "        if (value) then\n" +
+                "          if (string.match(value, predicate)) then\n" +
+                "            if (min_score == -1 or tonumber(element[2]) < min_score) then\n" +
+                "              min_score = tonumber(element[2])\n" +
+                "              owning_shard_idx=i\n" +
+                "              min_member = element[1]\n" +
+                "              matching_value = value\n" +
+                "            end\n" +
                 "          end\n" +
                 "        end\n" +
                 "      end\n" +


### PR DESCRIPTION
In some weird cases, we find the message in the queue but without a
payload in the hashmap. Although this is never expected, it seems to
happen, and this patch should stop the bleeding until we find out the
root cause.