### PR TITLE
Add findStaleMessages() API

### DIFF
--- a/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
+++ b/dyno-queues-core/src/main/java/com/netflix/dyno/queues/DynoQueue.java
@@ -234,6 +234,16 @@ public interface DynoQueue extends Closeable {
     public void processUnacks();
 	public void atomicProcessUnacks();
 
+	/**
+	 *
+	 * Attempts to return the items present in the local queue shard but not in the hashmap, if any.
+	 * (Ideally, we would not require this function, however, in some configurations, especially with multi-region write
+	 * traffic sharing the same queue, we may find ourselves with stale items in the queue shards)
+	 *
+	 * @return List of stale messages IDs.
+	 */
+	public List<Message> findStaleMessages();
+
 	/*
 	 * <=== Begin unsafe* functions. ===>
 	 *

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/MultiRedisQueue.java
@@ -260,6 +260,9 @@ public class MultiRedisQueue implements DynoQueue {
     }
 
     @Override
+    public List<Message> findStaleMessages() { throw new UnsupportedOperationException(); }
+
+    @Override
     public boolean atomicRemove(String messageId) {
         throw new UnsupportedOperationException();
     }

--- a/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
+++ b/dyno-queues-redis/src/main/java/com/netflix/dyno/queues/redis/v2/RedisPipelineQueue.java
@@ -690,6 +690,9 @@ public class RedisPipelineQueue implements DynoQueue {
     }
 
     @Override
+    public List<Message> findStaleMessages() { throw new UnsupportedOperationException(); }
+
+    @Override
     public boolean atomicRemove(String messageId) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
Attempts to return the items present in the local queue shard
but not in the hashmap, if any.

(Ideally, we would not require this function, however, in some
configurations, especially with multi-region write traffic sharing
the same queue, we may find ourselves with stale items in the queue
shards)