### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,9 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url = 'https://plugins.gradle.org/m2'
+        }
     }
     
     dependencies {
@@ -27,7 +30,7 @@ subprojects {
     targetCompatibility = 1.8
 
     repositories {
-        jcenter()
+        mavenCentral()
 
         // oss-candidate for -rc.* verions:
         maven {


### PR DESCRIPTION
This replaces jcenter with maven central to avoid broken builds in the future

