### PR TITLE
refactor: Change GitHub Action version to address deprecation of v1/v2

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -31,14 +31,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -26,7 +26,10 @@ jobs:
         java: [ 8 ]
     name: CI with Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+      - run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Setup jdk
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -22,7 +22,10 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+      - run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Setup jdk 8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -27,14 +27,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -19,9 +19,12 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - run: |
+          git config --global user.name "Netflix OSS Maintainers"
+          git config --global user.email "netflixoss@netflix.com"
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -26,13 +26,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 8
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: |
             ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: |

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 }
 
 plugins {
-    id 'nebula.netflixoss' version '9.1.0'
+    id 'com.netflix.nebula.netflixoss' version '11.5.0'
 }
 
 // Establish version and status
@@ -23,7 +23,7 @@ apply plugin: 'project-report'
 
 subprojects {
     apply plugin: 'nebula.netflixoss'
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'project-report'
 
     sourceCompatibility = 1.8

--- a/dyno-queues-core/build.gradle
+++ b/dyno-queues-core/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
-	compile 'com.netflix.dyno:dyno-core:1.7.2-rc2'
-	testCompile "junit:junit:4.11"
+	api 'com.netflix.dyno:dyno-core:1.7.2-rc2'
+    testImplementation "junit:junit:4.11"
 }

--- a/dyno-queues-redis/build.gradle
+++ b/dyno-queues-redis/build.gradle
@@ -1,20 +1,20 @@
 dependencies {
     
-    compile  project(':dyno-queues-core')
+    api  project(':dyno-queues-core')
 
-    compile "com.google.inject:guice:3.0"
+    api "com.google.inject:guice:3.0"
 
-    compile 'com.netflix.dyno:dyno-core:1.7.2-rc2'
-    compile 'com.netflix.dyno:dyno-jedis:1.7.2-rc2'
-    compile 'com.netflix.dyno:dyno-demo:1.7.2-rc2'
+    api 'com.netflix.dyno:dyno-core:1.7.2-rc2'
+    api 'com.netflix.dyno:dyno-jedis:1.7.2-rc2'
+    api 'com.netflix.dyno:dyno-demo:1.7.2-rc2'
 
-    compile 'com.netflix.archaius:archaius-core:0.7.5'
-    compile 'com.netflix.servo:servo-core:0.12.17'
-    compile 'com.netflix.eureka:eureka-client:1.8.1'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.4.4'
-    
-    testCompile 'org.rarefiedredis.redis:redis-java:0.0.17'
-    testCompile "junit:junit:4.11"    
+    api 'com.netflix.archaius:archaius-core:0.7.5'
+    api 'com.netflix.servo:servo-core:0.12.17'
+    api 'com.netflix.eureka:eureka-client:1.8.1'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.4.4'
+
+    testImplementation 'org.rarefiedredis.redis:redis-java:0.0.17'
+    testImplementation "junit:junit:4.11"
 }
 
 tasks.withType(Test)  {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip


### PR DESCRIPTION
Starting February 1st, 2025, Github is closing down v1-v2 of actions/cache (read more about it in this [changelog announcement](https://app.github.media/e/er?s=88570519&lid=6815&elqTrackId=08a5e2ee0de44b669cfee44c72a218f2&elq=553eec1a7c454e1f86dace7dd5ce9583&elqaid=4282&elqat=1&elqak=8AF5E7AAA12E3C7C230E5849DC6FF5707A505F45E589E4FD0E873A034D6DD7B23D08)) as well as all previous versions of the @actions/cache package in actions/toolkit. Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.github.ChangeActionVersion?organizationId=TmV0ZmxpeA%3D%3D#defaults=W3sidmFsdWUiOiJhY3Rpb25zL2NhY2hlIiwibmFtZSI6ImFjdGlvbiJ9LHsidmFsdWUiOiJ2NCIsIm5hbWUiOiJ2ZXJzaW9uIn1d